### PR TITLE
qjson library renamed to "qjson-qt5"

### DIFF
--- a/JSONToMySQL/jsontomysql.pro
+++ b/JSONToMySQL/jsontomysql.pro
@@ -15,7 +15,7 @@ CONFIG   -= app_bundle
 TEMPLATE = app
 
 unix:INCLUDEPATH += /usr/include ../3rdparty
-unix:LIBS += -L/usr/lib64 -l qjson
+unix:LIBS += -L/usr/lib64 -l qjson-qt5
 
 SOURCES += main.cpp \
     insertvalues.cpp

--- a/JSONToMySQL/main.cpp
+++ b/JSONToMySQL/main.cpp
@@ -19,7 +19,7 @@ License along with ODKTools.  If not, see <http://www.gnu.org/licenses/lgpl-3.0.
 */
 
 #include <QCoreApplication>
-#include <qjson/parser.h>
+#include <qjson-qt5/parser.h>
 #include <tclap/CmdLine.h>
 #include <QSqlDatabase>
 #include <QSqlError>


### PR DESCRIPTION
This fixes a compile error due to inability to find library "qjson" in recent build.

Using Ubuntu 14.04, I encountered an error in the final `make` command while following the [building and testing](https://github.com/ilri/odktools#building-and-testing) guide. 

I think this  is due to an update in qjson code to allow for simultaneous installs of qt4 and qt5. (Or something like that - I think [this commit](https://github.com/flavio/qjson/commit/1295e1bbca68c9dd73719436319324a75d9a68a1) is the cause.

This fix from my fork is tested and working on Ubuntu 14.04.  Not sure how to test on other platforms.  Happy to do so, if someone can point me in the right direction for how to compile these sort of apps in Mac or Windows. 
