### PR TITLE
Changes in MySQLDenormalize and JSONToMySQL

### DIFF
--- a/JSONToMySQL/main.cpp
+++ b/JSONToMySQL/main.cpp
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
     TCLAP::SwitchArg overwriteSwitch("w","overwrite","Overwrite the log file", cmd, false);
     TCLAP::SwitchArg oputSQLSwitch("S","outputSQL","Output each insert SQL to ./inputfile.json.sql", cmd, false);
     TCLAP::ValueArg<std::string> mapDirArg("M","mapoutputdir","Map output directory",false,"./recordMaps","string");
+    TCLAP::ValueArg<std::string> outTypeArg("O","outputtype","OutputType: (h)uman readable or (m)achine readble",false,"m","string");
 
     //These two parameters should be removed once the external script code works
 
@@ -71,6 +72,7 @@ int main(int argc, char *argv[])
     cmd.add(outputArg);
     cmd.add(inputArg);
     cmd.add(mapDirArg);
+    cmd.add(outTypeArg);
     cmd.add(JSArg);
 
     //Parsing the command lines
@@ -90,10 +92,11 @@ int main(int argc, char *argv[])
     QString input = QString::fromUtf8(inputArg.getValue().c_str());
     QString javaScript = QString::fromUtf8(JSArg.getValue().c_str());
     QString mapDirectory = QString::fromUtf8(mapDirArg.getValue().c_str());
+    QString outputType = QString::fromUtf8(outTypeArg.getValue().c_str());
 
     mainClass *task = new mainClass(&app);
 
-    task->setParameters(overwrite,json,manifest,host,port,user,password,schema,output,input,javaScript,oputSQLSwitch.getValue(),mapDirectory);
+    task->setParameters(overwrite,json,manifest,host,port,user,password,schema,output,input,javaScript,oputSQLSwitch.getValue(),mapDirectory,outputType);
 
     QObject::connect(task, SIGNAL(finished()), &app, SLOT(quit()));
 

--- a/JSONToMySQL/mainclass.h
+++ b/JSONToMySQL/mainclass.h
@@ -60,7 +60,7 @@ signals:
     void finishedWithError(int error);
 public slots:
     void run();
-    void setParameters(bool voverwrite, QString vjson, QString vmanifest, QString vhost, QString vport, QString vuser, QString vpassword, QString vschema, QString voutput, QString vinput, QString vjavaScript, bool voputSQLSwitch, QString mapDirectory);
+    void setParameters(bool voverwrite, QString vjson, QString vmanifest, QString vhost, QString vport, QString vuser, QString vpassword, QString vschema, QString voutput, QString vinput, QString vjavaScript, bool voputSQLSwitch, QString mapDirectory, QString outputType);
 private:
 
     int getLastIndex(QString table);
@@ -87,8 +87,12 @@ private:
     QString fileID;
     QString mainTable;
 
+    //Huma logging
     QFile logFile;
     QTextStream logStream;
+    //Machine loggin
+    QDomDocument xmlLog;
+    QDomElement eErrors;
 
     bool outSQL;
     QFile sqlFile;
@@ -111,6 +115,7 @@ private:
     QString input;
     QString javaScript;
     QString mapOutputDir;
+    QString outputType;
 };
 
 #endif // MAINCLASS_H

--- a/utilities/MySQLDenormalize/MySQLDenormalize.pro
+++ b/utilities/MySQLDenormalize/MySQLDenormalize.pro
@@ -16,7 +16,9 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-unix:INCLUDEPATH += ../../3rdparty
+unix:INCLUDEPATH += ../../3rdparty /usr/include/mongocxx/v_noabi /usr/include/bsoncxx/v_noabi
+
+unix:LIBS += -L/lib64 -L/usr/lib64 -lmongocxx -lbsoncxx
 
 SOURCES += main.cpp \
     mainclass.cpp

--- a/utilities/MySQLDenormalize/main.cpp
+++ b/utilities/MySQLDenormalize/main.cpp
@@ -31,7 +31,8 @@ int main(int argc, char *argv[])
     TCLAP::ValueArg<std::string> tableArg("t","maintable","Main table to denormalize from",true,"","string");
     TCLAP::ValueArg<std::string> mapArg("m","mapdirectory","Directory containing the map XML files",true,"","string");
     TCLAP::ValueArg<std::string> outArg("o","output","Output directory to store the JSON result files",false,"CSV","string");
-    TCLAP::SwitchArg remoteSwitch("T","protected","Include protected", cmd, false);
+    TCLAP::ValueArg<std::string> tmpArg("T","tempdir","Temporary directory (./tmp by default)",false,"./tmp","string");
+    TCLAP::SwitchArg remoteSwitch("i","includeprotected","Include protected", cmd, false);
 
 
     cmd.add(hostArg);
@@ -42,6 +43,7 @@ int main(int argc, char *argv[])
     cmd.add(tableArg);
     cmd.add(mapArg);
     cmd.add(outArg);
+    cmd.add(tmpArg);
     //Parsing the command lines
     cmd.parse( argc, argv );
 
@@ -57,9 +59,10 @@ int main(int argc, char *argv[])
     QString table = QString::fromUtf8(tableArg.getValue().c_str());
     QString mapDir = QString::fromUtf8(mapArg.getValue().c_str());
     QString output = QString::fromUtf8(outArg.getValue().c_str());
+    QString tmpDir = QString::fromUtf8(tmpArg.getValue().c_str());
 
     mainClass *task = new mainClass(&app);
-    task->setParameters(host,port,user,pass,schema,table,mapDir,output,includeProtected);
+    task->setParameters(host,port,user,pass,schema,table,mapDir,output,includeProtected,tmpDir);
     QObject::connect(task, SIGNAL(finished()), &app, SLOT(quit()));
     QTimer::singleShot(0, task, SLOT(run()));
     app.exec();

--- a/utilities/MySQLDenormalize/mainclass.cpp
+++ b/utilities/MySQLDenormalize/mainclass.cpp
@@ -23,6 +23,12 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/types.hpp>
+#include <mongocxx/options/find.hpp>
+#include <bsoncxx/stdx/string_view.hpp>
+
+#include <iostream>
+
+using bsoncxx::builder::basic::kvp;
 
 namespace pt = boost::property_tree;
 
@@ -38,7 +44,7 @@ void mainClass::log(QString message)
     printf(temp.toLocal8Bit().data());
 }
 
-void mainClass::setParameters(QString host, QString port, QString user, QString pass, QString schema, QString table, QString mapDir, QString output, bool includeProtected)
+void mainClass::setParameters(QString host, QString port, QString user, QString pass, QString schema, QString table, QString mapDir, QString output, bool includeProtected, QString tempDir)
 {
     this->host = host;
     this->port = port;
@@ -49,6 +55,7 @@ void mainClass::setParameters(QString host, QString port, QString user, QString 
     this->mapDir = mapDir;
     this->output = output;
     this->includeProtected = includeProtected;
+    this->tempDir = tempDir;
 }
 
 //This function goes trough a series of tables and their childs
@@ -66,55 +73,24 @@ void mainClass::processChilds(QDomDocument doc, QDomElement &parent, QString tab
     }
 }
 
-QList<TfieldDef> mainClass::getDataByRowUUID(QSqlDatabase db, QString tableToSearch, QString UUIDToSearch)
-{
-    QList<TfieldDef> records;
-    QSqlQuery qry(db);
-    QString sql;
-    sql = "SELECT * FROM " + tableToSearch + " WHERE rowuuid = '" + UUIDToSearch + "'";
-    qry.exec(sql);
-    if (qry.first())
-    {
-        QSqlRecord record = qry.record();
-        for (int pos = 0; pos <= record.count()-1; pos++)
-        {
-            QString fieldName;
-            fieldName = record.fieldName(pos);
-            TfieldDef aRecord;
-            aRecord.name = fieldName;
-            aRecord.value = qry.value(fieldName).toString();
-            records.append(aRecord);
-        }
-    }
-    if (records.count() == 0)
-    {
-        log("Empty result for " + tableToSearch + " with UUID " + UUIDToSearch);
-    }
-    return records;
-}
-
-//This function uses mongo to search for the data associated with a UUID in a table.
-//It has been replaced by directly searching the database using an index on rowuuid
-//This function return a list of fields (Field name, Field value)
-//QList<TfieldDef> mainClass::getDataByRowUUID2(mongocxx::collection collection, QString tableToSearch, QString UUIDToSearch)
+//QList<TfieldDef> mainClass::getDataByRowUUID3(QSqlDatabase db, QString tableToSearch, QString UUIDToSearch)
 //{
 //    QList<TfieldDef> records;
-//    bsoncxx::stdx::optional<bsoncxx::document::value> query_result =
-//    collection.find_one(bsoncxx::builder::stream::document{} << "_tablename" << tableToSearch.toUtf8().constData() << "rowuuid" << UUIDToSearch.toUtf8().constData() << bsoncxx::builder::stream::finalize);
-//    if(query_result)
+//    QSqlQuery qry(db);
+//    QString sql;
+//    sql = "SELECT * FROM " + tableToSearch + " WHERE rowuuid = '" + UUIDToSearch + "' limit 1";
+//    qry.exec(sql);
+//    if (qry.first())
 //    {
-//        std::string res = bsoncxx::to_json(*query_result);
-//        QString result = QString::fromStdString(res);
-//        QJsonDocument doc = QJsonDocument::fromJson(result.toUtf8());
-//        QJsonObject obj = doc.object();
-//        QStringList keys = obj.keys();
-//        for (int pos = 0; pos <= keys.count()-1; pos++)
+//        QSqlRecord record = qry.record();
+//        for (int pos = 0; pos <= record.count()-1; pos++)
 //        {
-//            QJsonValue value = obj.value(keys[pos]);
-//            TfieldDef aValue;
-//            aValue.name = keys[pos];
-//            aValue.value = value.toString();
-//            records.append(aValue);
+//            QString fieldName;
+//            fieldName = record.fieldName(pos);
+//            TfieldDef aRecord;
+//            aRecord.name = fieldName;
+//            aRecord.value = qry.value(fieldName).toString();
+//            records.append(aRecord);
 //        }
 //    }
 //    if (records.count() == 0)
@@ -124,11 +100,57 @@ QList<TfieldDef> mainClass::getDataByRowUUID(QSqlDatabase db, QString tableToSea
 //    return records;
 //}
 
+//This function uses mongo to search for the data associated with a UUID in a table.
+//This function return a list of fields (Field name, Field value)
+QList<TfieldDef> mainClass::getDataByRowUUID2(mongocxx::collection collection, QString tableToSearch, QString UUIDToSearch)
+{
+    QList<TfieldDef> records;
+    bsoncxx::stdx::optional<bsoncxx::document::value> query_result =
+    collection.find_one(bsoncxx::builder::stream::document{} << "_tablename" << tableToSearch.toUtf8().constData() << "rowuuid" << UUIDToSearch.toUtf8().constData() << bsoncxx::builder::stream::finalize);
+    if(query_result)
+    {
+        std::string res = bsoncxx::to_json(*query_result);
+        QString result = QString::fromStdString(res);
+        QJsonDocument doc = QJsonDocument::fromJson(result.toUtf8());
+        QJsonObject obj = doc.object();
+        QStringList keys = obj.keys();
+        for (int pos = 0; pos <= keys.count()-1; pos++)
+        {
+            QJsonValue value = obj.value(keys[pos]);
+            TfieldDef aValue;
+            aValue.name = keys[pos];
+            aValue.value = value.toString();
+            records.append(aValue);
+        }
+    }
+    if (records.count() == 0)
+    {
+        log("Empty result for " + tableToSearch + " with UUID " + UUIDToSearch);
+    }
+    return records;
+}
+
+QList<TfieldDef> mainClass::getDataByRowUUID4(QList<TUUIDDef> dataList, QString tableToSearch, QString UUIDToSearch)
+{
+    QList<TfieldDef> records;
+    for (int pos = 0; pos <= dataList.count()-1;pos++)
+    {
+        if ((dataList[pos].table == tableToSearch) && (dataList[pos].UUID == UUIDToSearch))
+        {
+            records.append(dataList[pos].fields);
+        }
+    }
+    if (records.count() == 0)
+    {
+        log("Empty result for " + tableToSearch + " with UUID " + UUIDToSearch);
+    }
+    return records;
+}
 
 //This function uses xmllint to search for the data associated with a UUID in a table.
 //It has been replaced by directly searching the database using an index on rowuuid
 //This function return a list of fields (Field name, Field value)
-//QList<TfieldDef> mainClass::getDataByRowUUID(QString tableToSearch, QString UUIDToSearch)
+//QList<TfieldDef> mainClass::getDataByRowUUID3(QString tableToSearch, QString UUIDToSearch)
 //{
 //    QList<TfieldDef> records;
 //    QString program = "xmllint";
@@ -173,7 +195,7 @@ QList<TfieldDef> mainClass::getDataByRowUUID(QSqlDatabase db, QString tableToSea
 //This function parse a Map File and returs the data tree in JSON form
 //This is a recursive fuction
 //mongocxx::collection collection
-void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, QString currentTable, QJsonObject &parent)
+void mainClass::parseMapFile(QList <TUUIDDef> dataList, QDomNode node, QJsonObject &json, QString currentTable, QJsonObject &parent)
 {
     QDomElement elem;
     elem = node.toElement();
@@ -184,7 +206,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
 
     //Get the data for a UUID in a table and add it to the JSON object
     QList<TfieldDef> records;
-    records = getDataByRowUUID(db,tableName,UUID);
+    records = getDataByRowUUID4(dataList,tableName,UUID);
     for (int pos = 0; pos <= records.count()-1; pos++)
     {
         json[records[pos].name] = records[pos].value;
@@ -197,7 +219,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
         tableName = elem.attribute("table");
         json[tableName] = QJsonArray();
         QJsonObject childObject;
-        parseMapFile(db,node.firstChild(),childObject,tableName,json);
+        parseMapFile(dataList,node.firstChild(),childObject,tableName,json);
         QJsonArray array = json[tableName].toArray();
         array.append(childObject);
         json[tableName] = array;
@@ -224,7 +246,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
                 QJsonArray array2 = parent[tableName].toArray();
                 QJsonObject childObject2;
                 QList<TfieldDef> records2;
-                records2 = getDataByRowUUID(db,tableName,UUID);
+                records2 = getDataByRowUUID4(dataList,tableName,UUID);
                 for (int pos = 0; pos <= records2.count()-1; pos++)
                 {
                     childObject2[records2[pos].name] = records2[pos].value;
@@ -239,7 +261,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
                     tableName2 = elem2.attribute("table");
                     childObject2[tableName2] = QJsonArray();
                     QJsonObject childObject3;
-                    parseMapFile(db,nextSibling.firstChild(),childObject3,currTable,childObject2);
+                    parseMapFile(dataList,nextSibling.firstChild(),childObject3,currTable,childObject2);
                     QJsonArray array3;
                     array3 = childObject2[tableName2].toArray();
                     array3.append(childObject3);
@@ -255,7 +277,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
                 //means is a sibling record in a table
                 QJsonObject childObject2;
                 QList<TfieldDef> records2;
-                records2 = getDataByRowUUID(db,tableName,UUID);
+                records2 = getDataByRowUUID4(dataList,tableName,UUID);
                 for (int pos = 0; pos <= records2.count()-1; pos++)
                 {
                     childObject2[records2[pos].name] = records2[pos].value;
@@ -271,7 +293,7 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
                     tableName2 = elem2.attribute("table");
                     childObject2[tableName2] = QJsonArray();
                     QJsonObject childObject3;
-                    parseMapFile(db,nextSibling.firstChild(),childObject3,currTable,childObject2);
+                    parseMapFile(dataList,nextSibling.firstChild(),childObject3,currTable,childObject2);
                     QJsonArray array3;
                     array3 = childObject2[tableName2].toArray();
                     array3.append(childObject3);
@@ -286,10 +308,27 @@ void mainClass::parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, 
     }
 }
 
+void mainClass::getAllUUIDs(QDomNode node,QStringList &UUIDs)
+{
+    QDomNode sibling;
+    sibling = node;
+    while (!sibling.isNull())
+    {
+        QDomElement eSibling;
+        eSibling = sibling.toElement();
+        QString UUID;
+        UUID = eSibling.attribute("table","None") + "~" + eSibling.attribute("uuid","None");
+        UUIDs.append(UUID);
+        if (!sibling.firstChild().isNull())
+            getAllUUIDs(sibling.firstChild(),UUIDs);
+        sibling = sibling.nextSibling();
+    }
+}
+
 //This function receives a Map File and construct a JSON file with the data
 //The JSON file is stored in the ouput directy and has the same name
 //of the Map File
-void mainClass::processMapFile(QSqlDatabase db, QString fileName)
+void mainClass::processMapFile(mongocxx::collection collection, QString fileName)
 {
     QDir mapPath(mapDir);
     QString mapFile;
@@ -297,22 +336,79 @@ void mainClass::processMapFile(QSqlDatabase db, QString fileName)
     QDomDocument doc("mapfile");
     QFile file(mapFile);
     if (!file.open(QIODevice::ReadOnly))
+    {
+        log("Map file " + mapFile + " not found");
         return;
-    if (!doc.setContent(&file)) {
+    }
+    if (!doc.setContent(&file))
+    {
         file.close();
+        log("Cannot parse map file " + mapFile);
         return;
     }
     file.close();
     QDomNode root;
     root = doc.firstChild().nextSibling().firstChild();
 
+    //We here search in Mongo for the data of all UUDIDs and store the
+    //data in an array called dataList. By doing this we only go once
+    //to mongo
+    QStringList UUIDs;
+    getAllUUIDs(root,UUIDs);
+    QString mongoQry;
+    mongoQry = "{ \"$or\" :[";
+    for (int pos = 0; pos <= UUIDs.count()-1;pos++)
+    {
+        QStringList parts;
+        parts = UUIDs[pos].split('~');
+        mongoQry = mongoQry + "{\"_tablename\":\"" + parts[0] + "\",\"rowuuid\":\"" + parts[1] + "\"},";
+    }
+    mongoQry = mongoQry.left(mongoQry.length()-1);
+    mongoQry = mongoQry + "]}";
+    std::string utf8_text = mongoQry.toUtf8().constData();
+    bsoncxx::string::view_or_value qry(utf8_text);
+    bsoncxx::document::value bsondoc = bsoncxx::from_json(qry.view());
+    auto cursor = collection.find(bsondoc.view());
+    QList <TUUIDDef> dataList;
+    for (const bsoncxx::document::view& doc : cursor)
+    {
+        TUUIDDef aTable;
+        for (bsoncxx::document::element ele : doc)
+        {
+            if (ele.type() == bsoncxx::type::k_utf8)
+            {
+                mongocxx::stdx::string_view field_key{ele.key()};
+                QString key = QString::fromUtf8(field_key.data());
+                QString value;
+                value = QString::fromUtf8(ele.get_utf8().value.data());
+                if ((key != "_tablename") && (key != "rowuuid"))
+                {
+                    TfieldDef aField;
+                    aField.name = key;
+                    aField.value = value;
+                    aTable.fields.append(aField);
+                }
+                else
+                {
+                    if (key == "_tablename")
+                        aTable.table = value;
+                    else
+                        aTable.UUID = value;
+                }
+            }
+        }
+        dataList.append(aTable);
+    }
+    //Now that we have the data contruct the tree with the data
+    //comming from the database
     QDomElement elem;
     elem = root.toElement();
     QString tableName;
     tableName = elem.attribute("table");
     QJsonObject JSONRoot;
-    parseMapFile(db,root,JSONRoot,tableName,JSONRoot);
+    parseMapFile(dataList,root,JSONRoot,tableName,JSONRoot);
 
+    //Finally save the JSON document
     QJsonDocument saveDoc(JSONRoot);
     QDir outputPath(output);
     QString JSONFile;
@@ -327,14 +423,11 @@ void mainClass::processMapFile(QSqlDatabase db, QString fileName)
     saveFile.close();
 }
 
-//This function was another attempt to minimize the time
-//Now is not neeed but commented until we are sure we don't need to go back
+//This uses insert many
 //void mainClass::parseDataToMongo(mongocxx::collection collection, QString table, QString fileName)
 //{
-
 //    pt::ptree tree;
 //    pt::read_xml(fileName.toUtf8().constData(), tree);
-
 //    BOOST_FOREACH(boost::property_tree::ptree::value_type const&db, tree.get_child("mysqldump") )
 //    {
 //        const boost::property_tree::ptree & aDatabase = db.second; // value (or a subnode)
@@ -344,32 +437,111 @@ void mainClass::processMapFile(QSqlDatabase db, QString fileName)
 //            if (key == "table_data")
 //            {
 //                const boost::property_tree::ptree & aTable = ctable.second;
+//                int rowNumber;
+//                rowNumber = 1;
+//                std::vector<bsoncxx::document::value> documents;
 //                BOOST_FOREACH(boost::property_tree::ptree::value_type const&row, aTable.get_child("") )
 //                {
 //                    const boost::property_tree::ptree & aRow = row.second;
-//                    auto doc = bsoncxx::builder::basic::document{};
-//                    using bsoncxx::builder::basic::kvp;
-//                    doc.append(kvp("_tablename", table.toUtf8().constData()));
-//                    BOOST_FOREACH(boost::property_tree::ptree::value_type const&field, aRow.get_child("") )
+//                    if (rowNumber <= 100000)
 //                    {
-//                        const std::string & fkey = field.first.data();
-//                        if (fkey == "field")
+//                        auto doc = bsoncxx::builder::basic::document{};
+////                        using bsoncxx::builder::basic::kvp;
+//                        doc.append(kvp("_tablename", table.toUtf8().constData()));
+//                        BOOST_FOREACH(boost::property_tree::ptree::value_type const&field, aRow.get_child("") )
 //                        {
-//                            const boost::property_tree::ptree & aField = field.second;
-//                            std::string fname = aField.get<std::string>("<xmlattr>.name");
-//                            std::string fvalue = aField.data();
-//                            doc.append(kvp(fname,fvalue));
+//                            const std::string & fkey = field.first.data();
+//                            if (fkey == "field")
+//                            {
+//                                const boost::property_tree::ptree & aField = field.second;
+//                                std::string fname = aField.get<std::string>("<xmlattr>.name");
+//                                std::string fvalue = aField.data();
+//                                doc.append(kvp(fname,fvalue));
+//                            }
+//                            //QJsonDocument doc(JSONRow);
+//                            //QString JSONString(doc.toJson(QJsonDocument::Compact));
 //                        }
-//                        //QJsonDocument doc(JSONRow);
-//                        //QString JSONString(doc.toJson(QJsonDocument::Compact));
+//                        documents.push_back(doc.extract());
+//                        rowNumber++;
 //                    }
-//                    collection.insert_one(doc.view());
+//                    else
+//                    {
+//                        collection.insert_many(documents);
+//                        documents.clear();
+//                        auto doc = bsoncxx::builder::basic::document{};
+//                        using bsoncxx::builder::basic::kvp;
+//                        doc.append(kvp("_tablename", table.toUtf8().constData()));
+//                        BOOST_FOREACH(boost::property_tree::ptree::value_type const&field, aRow.get_child("") )
+//                        {
+//                            const std::string & fkey = field.first.data();
+//                            if (fkey == "field")
+//                            {
+//                                const boost::property_tree::ptree & aField = field.second;
+//                                std::string fname = aField.get<std::string>("<xmlattr>.name");
+//                                std::string fvalue = aField.data();
+//                                doc.append(kvp(fname,fvalue));
+//                            }
+//                            //QJsonDocument doc(JSONRow);
+//                            //QString JSONString(doc.toJson(QJsonDocument::Compact));
+//                        }
+//                        documents.push_back(doc.extract());
+//                        rowNumber=1;
+//                    }
+//                    //collection.insert_one(doc.view());
 //                }
-
+//                if (documents.size() > 0)
+//                {
+//                    collection.insert_many(documents);
+//                }
 //            }
 //        }
 //    }
 //}
+
+//This function creates a bulk insert of the XML data into Mongo
+void mainClass::parseDataToMongo(mongocxx::collection collection, QString table, QString fileName)
+{
+    pt::ptree tree;
+    pt::read_xml(fileName.toUtf8().constData(), tree);
+    BOOST_FOREACH(boost::property_tree::ptree::value_type const&db, tree.get_child("mysqldump") )
+    {
+        const boost::property_tree::ptree & aDatabase = db.second; // value (or a subnode)
+        BOOST_FOREACH(boost::property_tree::ptree::value_type const&ctable, aDatabase.get_child("") )
+        {
+            const std::string & key = ctable.first.data();
+            if (key == "table_data")
+            {
+                const boost::property_tree::ptree & aTable = ctable.second;
+                mongocxx::bulk_write bulk{};
+                BOOST_FOREACH(boost::property_tree::ptree::value_type const&row, aTable.get_child("") )
+                {
+                    const boost::property_tree::ptree & aRow = row.second;
+
+                    auto doc = bsoncxx::builder::basic::document{};
+                    //                        using bsoncxx::builder::basic::kvp;
+                    doc.append(kvp("_tablename", table.toUtf8().constData()));
+                    BOOST_FOREACH(boost::property_tree::ptree::value_type const&field, aRow.get_child("") )
+                    {
+                        const std::string & fkey = field.first.data();
+                        if (fkey == "field")
+                        {
+                            const boost::property_tree::ptree & aField = field.second;
+                            std::string fname = aField.get<std::string>("<xmlattr>.name");
+                            std::string fvalue = aField.data();
+                            doc.append(kvp(fname,fvalue));
+                        }
+                        //QJsonDocument doc(JSONRow);
+                        //QString JSONString(doc.toJson(QJsonDocument::Compact));
+                    }
+                    mongocxx::model::insert_one insert_op{doc.view()};
+                    bulk.append(insert_op);
+                }
+                collection.bulk_write(bulk);
+            }
+        }
+    }
+}
+
 
 //This is the starter function. It queries the database for the relationships
 //and get the child tables of the starting table (main table)
@@ -391,86 +563,125 @@ int mainClass::generateJSONs(QSqlDatabase db)
         aTable.parent = rels.value("REFERENCED_TABLE_NAME").toString();
         tables.append(aTable);
     }
-    //We create an XML document to store the relationships
-    QDomDocument outputdoc;
-    outputdoc = QDomDocument("DBStructFile");
-    QDomElement root;
-    root = outputdoc.createElement("tables");
-    root.setAttribute("version", "1.0");
-    outputdoc.appendChild(root);
-    //We get the tables used from the starting table
-    QStringList tablesUsed;
-    processChilds(outputdoc,root,table,tables,tablesUsed);
-
-    /*
-    This code has been replaced to directly get the data from MySQL using an index on rowuuid
-    We leave it here for a while until we are sure we will not need it.
-    //Connects to MONGO
-    mongocxx::instance instance{}; // This should be done only once.
-    mongocxx::uri uri("mongodb://localhost:27017");
-    mongocxx::client client(uri);
-    mongocxx::database mongoDB = client["mysqldenormalize"];
-    //We create a collection based on the last 12 digits of a UUID
-    QUuid collectionUUID=QUuid::createUuid();
-    QString strCollectionUUID=collectionUUID.toString().replace("{","").replace("}","");
-    strCollectionUUID = "C" + strCollectionUUID.right(12);
-    mongocxx::collection coll = mongoDB[strCollectionUUID.toUtf8().constData()];
-
-    auto index_specification = bsoncxx::builder::stream::document{} << "_tablename" << 1 << "rowuuid" << 1 << bsoncxx::builder::stream::finalize;
-    coll.create_index(std::move(index_specification));
-    //Call MySQLDump to export each table as XML
-    //We use MySQLDump because it very very fast
-    QDir currDir(".");
-    currDir.mkdir("tmp");
-    QString program = "mysqldump";
-    QStringList arguments;
-    QProcess *mySQLDumpProcess = new QProcess();
-    for (int pos = 0; pos <= tablesUsed.count()-1; pos++)
+    if (tables.count() > 0)
     {
-        arguments.clear();
-        arguments << "--single-transaction";
-        arguments << "-h" << host;
-        arguments << "-u" << user;
-        arguments << "--password=" + pass;
-        arguments << "--skip-triggers";
-        arguments << "--xml";
-        arguments << "--no-create-info";
-        arguments << schema;
-        arguments << tablesUsed[pos];
-        mySQLDumpProcess->setStandardOutputFile("./tmp/" + tablesUsed[pos] + ".xml");
-        mySQLDumpProcess->start(program, arguments);
-        log("Exporting " + tablesUsed[pos] + " to Mongo");
-        mySQLDumpProcess->waitForFinished(-1);
-        parseDataToMongo(coll,tablesUsed[pos],"./tmp/" + tablesUsed[pos] + ".xml");
+        //We create an XML document to store the relationships
+        QDomDocument outputdoc;
+        outputdoc = QDomDocument("DBStructFile");
+        QDomElement root;
+        root = outputdoc.createElement("tables");
+        root.setAttribute("version", "1.0");
+        outputdoc.appendChild(root);
+        //We get the tables used from the starting table
+        QStringList tablesUsed;
+        processChilds(outputdoc,root,table,tables,tablesUsed);
+        if (tablesUsed.count() > 0)
+        {
+            //We moved all the neccesary data into a Mongo Collection
+            //The data is exported first to XML using MySQLDump
+            //then using Boost to parse the XML and then do a bulk insert
+            //into mongo.
+
+            //This is the most efficient way to do this at this moment
+            //because querying MySQL to extract data will affect
+            //the performace if the server is heavily loaded by other processes
+
+            //Connects to MONGO
+            mongocxx::instance instance{}; // This should be done only once.
+            mongocxx::uri uri("mongodb://localhost:27017");
+            mongocxx::client client(uri);
+            mongocxx::database mongoDB = client["mysqldenormalize"];
+            //We create a collection based on the last 12 digits of a UUID
+            QUuid collectionUUID=QUuid::createUuid();
+            QString strCollectionUUID=collectionUUID.toString().replace("{","").replace("}","");
+            strCollectionUUID = "C" + strCollectionUUID.right(12);
+            mongocxx::collection coll = mongoDB[strCollectionUUID.toUtf8().constData()];
+
+            auto index_specification = bsoncxx::builder::stream::document{} << "_tablename" << 1 << "rowuuid" << 1 << bsoncxx::builder::stream::finalize;
+            coll.create_index(std::move(index_specification));
+            //Call MySQLDump to export each table as XML
+            //We use MySQLDump because it very very fast
+            QDir currDir(tempDir);
+            QString program = "mysqldump";
+            QStringList arguments;
+            QProcess *mySQLDumpProcess = new QProcess();
+            log("Exporting data to Mongo");
+            QTime procTime;
+            procTime.start();
+            for (int pos = 0; pos <= tablesUsed.count()-1; pos++)
+            {
+                arguments.clear();
+                arguments << "--single-transaction";
+                arguments << "-h" << host;
+                arguments << "-u" << user;
+                arguments << "--password=" + pass;
+                arguments << "--skip-triggers";
+                arguments << "--xml";
+                arguments << "--no-create-info";
+                arguments << schema;
+                arguments << tablesUsed[pos];
+                mySQLDumpProcess->setStandardOutputFile(currDir.absolutePath() + currDir.separator() + tablesUsed[pos] + ".xml");
+                mySQLDumpProcess->start(program, arguments);
+                mySQLDumpProcess->waitForFinished(-1);
+                if ((mySQLDumpProcess->exitCode() > 0) || (mySQLDumpProcess->error() == QProcess::FailedToStart))
+                {
+                    if (mySQLDumpProcess->error() == QProcess::FailedToStart)
+                    {
+                        log("Error: Command " +  program + " not found");
+                    }
+                    else
+                    {
+                        log("Running mysqldump returned error");
+                        QString serror = mySQLDumpProcess->readAllStandardError();
+                        log(serror);
+                        log("Running paremeters:" + arguments.join(" "));
+                    }
+                    return 1;
+                }
+                else
+                    parseDataToMongo(coll,tablesUsed[pos],currDir.absolutePath() + currDir.separator() + tablesUsed[pos] + ".xml");
+            }
+            delete mySQLDumpProcess;
+
+            //Select the Survey IDs that will be exported
+            sql = "SELECT surveyid FROM " + table;
+            //sql = "SELECT surveyid FROM " + table + " WHERE surveyid = '9a1fab77-c7a7-4de7-8a87-faf4521d67b5'";
+            QStringList lstIds;
+            QSqlQuery qryIds(db);
+            qryIds.exec(sql);
+            while (qryIds.next())
+                lstIds << qryIds.value(0).toString();
+
+            log("Generating trees");
+            for (int pos = 0; pos <= lstIds.count()-1; pos++)
+            {
+                processMapFile(coll,lstIds[pos]);
+            }
+            coll.drop();
+            int Hours;
+            int Minutes;
+            int Seconds;
+            int Milliseconds;
+
+            Milliseconds = procTime.elapsed();
+            Hours = Milliseconds / (1000*60*60);
+            Minutes = (Milliseconds % (1000*60*60)) / (1000*60);
+            Seconds = ((Milliseconds % (1000*60*60)) % (1000*60)) / 1000;
+            log("Finished in " + QString::number(Hours) + " Hours," + QString::number(Minutes) + " Minutes and " + QString::number(Seconds) + " Seconds.");
+
+            return 0;
+        }
+        else
+        {
+            log("No tables are in use. Check the main table");
+            return 1;
+        }
     }
-    */
-
-    //Select the Survey IDs that will be exported
-    sql = "SELECT surveyid FROM " + table;
-    QStringList lstIds;
-    QSqlQuery qryIds(db);
-    qryIds.exec(sql);
-    while (qryIds.next())
-        lstIds << qryIds.value(0).toString();
-
-    QTime procTime;
-    procTime.start();
-    for (int pos = 0; pos <= lstIds.count()-1; pos++)
+    else
     {
-        processMapFile(db,lstIds[pos]);
+        log("Can't query relationships");
+        return 1;
     }
-    int Hours;
-    int Minutes;
-    int Seconds;
-    int Milliseconds;
-
-    Milliseconds = procTime.elapsed();
-    Hours = Milliseconds / (1000*60*60);
-    Minutes = (Milliseconds % (1000*60*60)) / (1000*60);
-    Seconds = ((Milliseconds % (1000*60*60)) % (1000*60)) / 1000;
-    log("Finished in " + QString::number(Hours) + " Hours," + QString::number(Minutes) + " Minutes and " + QString::number(Seconds) + " Seconds.");
-
-    return 0;
 }
 
 void mainClass::run()
@@ -487,6 +698,17 @@ void mainClass::run()
             QDir outDir(output);
             if (outDir.exists())
             {
+                QDir tDir;
+                if (!tDir.exists(tempDir))
+                {
+                    if (!tDir.mkdir(tempDir))
+                    {
+                        log("Cannot create temporary directory");
+                        returnCode = -1;
+                        emit finished();
+                    }
+                }
+
                 QSqlDatabase db = QSqlDatabase::addDatabase("QMYSQL");
                 db.setHostName(host);
                 db.setPort(port.toInt());
@@ -505,6 +727,12 @@ void mainClass::run()
                         db.close();
                         emit finished();
                     }
+                }
+                else
+                {
+                    log("Cannot connect to the database");
+                    returnCode = -1;
+                    emit finished();
                 }
             }
             else

--- a/utilities/MySQLDenormalize/mainclass.h
+++ b/utilities/MySQLDenormalize/mainclass.h
@@ -29,12 +29,20 @@ struct fieldDef
 };
 typedef fieldDef TfieldDef;
 
+struct UUIDDef
+{
+    QString table;
+    QString UUID;
+    QList<TfieldDef> fields;
+};
+typedef UUIDDef TUUIDDef;
+
 class mainClass : public QObject
 {
     Q_OBJECT
 public:
     explicit mainClass(QObject *parent = nullptr);
-    void setParameters(QString host, QString port, QString user, QString pass, QString schema, QString table, QString mapDir, QString output, bool includeProtected);
+    void setParameters(QString host, QString port, QString user, QString pass, QString schema, QString table, QString mapDir, QString output, bool includeProtected, QString tempDir);
     int returnCode;
 signals:
     void finished();
@@ -45,11 +53,13 @@ private:
     int generateJSONs(QSqlDatabase db);
     void processChilds(QDomDocument doc, QDomElement &parent, QString table, QList <TtableDef> tables, QStringList &tablesUsed);
     //QList<TfieldDef> getDataByRowUUID(QString tableToSearch, QString UUIDToSearch);
-    void processMapFile(QSqlDatabase db, QString fileName);
-    void parseMapFile(QSqlDatabase db, QDomNode node, QJsonObject &json, QString currentTable, QJsonObject &parent);
+    void processMapFile(mongocxx::collection collection, QString fileName);
+    void parseMapFile(QList<TUUIDDef> dataList, QDomNode node, QJsonObject &json, QString currentTable, QJsonObject &parent);
     void parseDataToMongo(mongocxx::collection collection, QString table, QString fileName);
-    //QList<TfieldDef> getDataByRowUUID2(mongocxx::collection collection, QString tableToSearch, QString UUIDToSearch);
-    QList<TfieldDef> getDataByRowUUID(QSqlDatabase db, QString tableToSearch, QString UUIDToSearch);
+    QList<TfieldDef> getDataByRowUUID2(mongocxx::collection collection, QString tableToSearch, QString UUIDToSearch);
+    //QList<TfieldDef> getDataByRowUUID3(QSqlDatabase db, QString tableToSearch, QString UUIDToSearch);
+    QList<TfieldDef> getDataByRowUUID4(QList<TUUIDDef> dataList, QString tableToSearch, QString UUIDToSearch);
+    void getAllUUIDs(QDomNode node, QStringList &UUIDs);
     QString host;
     QString port;
     QString user;
@@ -59,6 +69,7 @@ private:
     QString mapDir;
     QString output;
     QString nullValue;
+    QString tempDir;
     bool includeProtected;
 };
 


### PR DESCRIPTION
MySQLDenormalize now uses Boost+Mongo so its performance does not depend on queries to the MySQL server. Data is exported with MySQLDump to XML then we use Boost to load it into Mongo. From there we are able to create the trees in a very fast way.

JSONToMySQL now produces logs in XML format for better integration with third-party applications and web services.