### PR TITLE
JSON2CSV-CPP has been wrapped with QMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ insertfromxml
 xmltojson
 mysqldenormalize
 jsontocsv
+json2csv
 
 #Other directories
 old

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ To build ODK Tools do:
         $ sudo make install
         $ cd ../../..
         $ cd dependencies/json2csv-cpp
+        $ qmake
         $ make
         $ sudo cp json2csv /usr/bin
         $ cd ../../..

--- a/dependencies/json2csv-cpp/.gitignore
+++ b/dependencies/json2csv-cpp/.gitignore
@@ -1,4 +1,73 @@
-x64/
-json2csv-cpp.v12.suo
-json2csv-cpp.sdf
-json2csv-cpp.opensdf
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/dependencies/json2csv-cpp/json2csv-cpp.pro
+++ b/dependencies/json2csv-cpp/json2csv-cpp.pro
@@ -1,0 +1,21 @@
+QT -= gui
+
+CONFIG += c++14 console
+CONFIG -= app_bundle
+TARGET = json2csv
+
+# The following define makes your compiler emit warnings if you use
+# any feature of Qt which as been marked deprecated (the exact warnings
+# depend on your compiler). Please consult the documentation of the
+# deprecated API in order to know how to port your code away from it.
+DEFINES += QT_DEPRECATED_WARNINGS
+
+# You can also make your code fail to compile if you use deprecated APIs.
+# In order to do so, uncomment the following line.
+# You can also select to disable deprecated APIs only up to a certain version of Qt.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+unix:INCLUDEPATH += /usr/local/include
+
+unix:LIBS += -L/usr/local/lib64 -L/usr/local/lib -ljsoncpp
+SOURCES += index.cpp


### PR DESCRIPTION
Since we lose the Makefile of JSON2CSV-CPP due to the Git ignore file we wrapped JSON2CSV-CPP inside a QMake project so the Makefile will be generated using qmake